### PR TITLE
Fix a typo in the for loop iterator variable.

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -177,7 +177,7 @@ export default class TicTacTocComponent extends React.Component {
     for (let y = 0;y < 3;y++) {
       const row = [];
 
-      for (let y = 0;y < 3;y++) {
+      for (let x = 0;x < 3;x++) {
         row.push(<td>{this.props.game.state.grid[y][x]}</td>);
       }
 


### PR DESCRIPTION
The `y` variable was reused inside of the nested `for` loop, which I believe to be a mistake. I assume this was just a copy/paste error.

It seems like `x` is being used for the second dimension of the array access (`....grid[y][x]`), so I updated the inner `for` loop to use `x`.