### PR TITLE
Add `npm init` to the setup of the tutorial.

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -13,6 +13,7 @@ Let's create a new Javascript project and install the Ravens engine:
 ```bash
 mkdir tic-tac-toe
 cd tic-tac-toe
+npm init
 npm install @ravens-engine/core
 ```
 


### PR DESCRIPTION
I was having trouble following the tutorial because `packages.json` was not generated. It seems I missed the obvious step of `npm init`.

This commit adds that to the steps of the tutorial.