### PR TITLE
Add missing react import from the Component tutorial.

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -171,6 +171,8 @@ npm install react react-dom parcel-bundler
 Let's create a file `src/TicTacToeComponent.jsx`, and fill the `render` function with an UI for our game:
 
 ```jsx
+import * as React from "react";
+
 export default class TicTacTocComponent extends React.Component {
   render() {
     let tableRows = [];


### PR DESCRIPTION
This is necessary to import react, otherwise you get `Uncaught ReferenceError: React is not defined`.