### PR TITLE
Add `tbody` tags to the table in the tutorial.

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -188,7 +188,9 @@ export default class TicTacTocComponent extends React.Component {
       <div style="display: flex; align-items: center">
         <div>{this.props.game.state.turn}</div>
         <table>
-          {tableRows}
+          <tbody>
+            {tableRows}
+          </tbody>
         </table>
       </div>
     );


### PR DESCRIPTION
This resolve the following error:

```
...cannot appear as a child of <table>. Add a <tbody>, <thead> or <tfoot> to your code to match the DOM tree generated by the browser.
```