### PR TITLE
Update the `style` to use a javascript object for `.jsx`.

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -185,7 +185,7 @@ export default class TicTacTocComponent extends React.Component {
     }
 
     return (
-      <div style="display: flex; align-items: center">
+      <div style={{ display: 'flex', alignItems: 'center'}}>
         <div>{this.props.game.state.turn}</div>
         <table>
           {tableRows}


### PR DESCRIPTION
Inline styling for `.jsx` needs to be a javascript object (source - https://www.w3schools.com/react/react_css.asp)

I was seeing this error otherwise:

```
Error: The `style` prop expects a mapping from style properties to values, not a string. For example, style={{marginRight: spacing + 'em'}} when using JSX.
    at assertValidProps (react-dom.development.js:2719)
    at setInitialProperties (react-dom.development.js:9134)
    at finalizeInitialChildren (react-dom.development.js:10201)
    at completeWork (react-dom.development.js:19470)
    at completeUnitOfWork (react-dom.development.js:22815)
    at performUnitOfWork (react-dom.development.js:22787)
    at workLoopSync (react-dom.development.js:22707)
    at renderRootSync (react-dom.development.js:22670)
    at performSyncWorkOnRoot (react-dom.development.js:22293)
    at react-dom.development.js:11327
```