### PR TITLE
Expose `GameStatus` in `index.ts`.

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,6 @@
 export * from "./Core";
 export * from "./Game";
+export * from "./GameStatus";
 export * from "./Phase";
 export * from "./errors/InvalidActionError";
 export * from "./errors/InvalidStatusError";


### PR DESCRIPTION
I'm unable to import `GameStatus` from the `@ravens-engine/core/lib/core/index.js`.

I am able to do:

```
import { GameStatus } from "@ravens-engine/core/lib/core/GameStatus.js";
```

However it seems like it would be convenient to expose it from this umbrella import `index.ts`.