### PR TITLE
Update the `parcel` invocation sites and localhost ports.

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -291,10 +291,10 @@ node ./src/server.js
 To launch the UI, run in an other terminal:
 
 ```sh
-parcel index.html
+npx parcel index.html
 ```
 
-You can now access the game by opening `http://localhost:8080`. You can click on the square to fill the
+You can now access the game by opening `http://localhost:1234`. You can click on the square to fill the
 
 ## Making it multiplayer
 
@@ -529,9 +529,9 @@ To launch the game:
 # In a terminal
 node ./src/server.js
 # In an other terminal
-parcel index.html
+npx parcel index.html
 ```
 
-You can access the game by opening `http://localhost:8080`.
+You can access the game by opening `http://localhost:1234`.
 
-To simulate a second player joining the game, access `http://localhost:8080#2`. You can simulate more players by increasing the number after the `#`.
+To simulate a second player joining the game, access `http://localhost:1234#2`. You can simulate more players by increasing the number after the `#`.


### PR DESCRIPTION
Fixes https://github.com/ravens-engine/core/issues/10

To run `parcel` on the command line, if not installed globally, it should be issued via `npx`. The default port is also `1234` and not `8080`. While you can specify a port with an argument to the call, it is simpler to just update the docs to reflect the default.