### PR TITLE
Fix a broken hyperlink to the tutorial.

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -24,7 +24,7 @@ can be properly understood.
 
 ### Through the tutorial
 
-There is [a step-by-step tutorial](./tutorial) that guides you through the creation of a Tic Tac Toe using Ravens.
+There is [a step-by-step tutorial](../tutorial) that guides you through the creation of a Tic Tac Toe using Ravens.
 
 ### Through examples
 


### PR DESCRIPTION
The link attempts to go to https://ravens.dev/docs/tutorial which is wrong. It should not go to `docs/tutorial` but instead should go straight to `/tutorial`.